### PR TITLE
update: recipeのカラム追加に伴う修正

### DIFF
--- a/app/Http/Controllers/RecipeController.php
+++ b/app/Http/Controllers/RecipeController.php
@@ -28,6 +28,8 @@ class RecipeController extends Controller
         $recipe = new Recipe();
         $recipe->name = $request->name;
         $recipe->cookingtime = $request->cookingtime;
+        $recipe->description = $request->description;
+        $recipe->is_comment_allowed = $request->is_comment_allowed;
         $recipe->save();
 
         return redirect("/recipe");
@@ -52,6 +54,8 @@ class RecipeController extends Controller
         $recipe = Recipe::findOrFail($id);
         $recipe->name = $request->name;
         $recipe->cookingtime = $request->cookingtime;
+        $recipe->description = $request->description;
+        $recipe->is_comment_allowed = $request->is_comment_allowed;
         $recipe->save();
 
         return redirect("/recipe");

--- a/database/migrations/2021_05_20_043807_add_description_to_recipes_table.php
+++ b/database/migrations/2021_05_20_043807_add_description_to_recipes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDescriptionToRecipesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->string('description')->after('cookingtime')->comment('説明');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->dropColumn(('description'));
+        });
+    }
+}

--- a/database/migrations/2021_05_20_052550_add_comment_accepted_to_recipes_table.php
+++ b/database/migrations/2021_05_20_052550_add_comment_accepted_to_recipes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCommentAcceptedToRecipesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->boolean('is_comment_allowed')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->dropColumn('is_comment_allowed');
+        });
+    }
+}

--- a/resources/views/recipe/form.blade.php
+++ b/resources/views/recipe/form.blade.php
@@ -1,40 +1,98 @@
 <div class="container ops-main">
-    <div class="row">
-        <div class="col-md-6">
-            <h2>レシピ登録</h2>
-        </div>
+  <div class="row">
+    <div class="col-md-6">
+      <h2>レシピ登録</h2>
     </div>
-    <div class="row">
-        <div class="col-md-8 col-md-offset-1">
-            @include('recipe/message')
-            @if ($target == 'store')
-                <form action="/recipe" method="post">
-            @elseif($target == 'update')
-                    <form action="/recipe/{{ $recipe->id }}" method="post">
-                        <input type="hidden" name="_method" value="PUT">
-            @endif
-            <input type="hidden" name="_token" value="{{ csrf_token() }}">
-            <div class="form-group">
-                <label for="name">レシピ名</label>
-                <input type="text" class="form-control" name="name" value="{{ $recipe->name }}">
-                @if ($errors->has('name'))
-                    @foreach ($errors->get('name') as $message)
-                        <span class="text-danger">{{ $message }}</span><br>
-                    @endforeach
-                @endif
-            </div>
-            <div class="form-group">
-                <label for="cookingtime">所要時間</label>
-                <input type="text" class="form-control" name="cookingtime" value="{{ $recipe->cookingtime }}">
-                @if ($errors->has('cookingtime'))
-                    @foreach ($errors->get('cookingtime') as $message)
-                        <span class="text-danger">{{ $message }}</span><br>
-                    @endforeach
-                @endif
-            </div>
-            <button type="submit" class="btn btn-default">登録</button>
-            <a href="/recipe">戻る</a>
-            </form>
-        </div>
+  </div>
+  <div class="row">
+    <div class="col-md-8 col-md-offset-1">
+      @include('recipe/message')
+      @if ($target == 'store')
+        <form action="/recipe" method="post">
+      @elseif($target == 'update')
+          <form action="/recipe/{{ $recipe->id }}" method="post">
+            <input type="hidden" name="_method" value="PUT">
+      @endif
+      <input type="hidden" name="_token" value="{{ csrf_token() }}">
+      <div class="form-group">
+        <label for="name">レシピ名</label>
+        <input type="text" class="form-control" name="name" value="{{ $recipe->name }}">
+        @if ($errors->has('name'))
+          @foreach ($errors->get('name') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+      <div class="form-group">
+        <label for="cookingtime">所要時間</label>
+        <input type="number" class="form-control" name="cookingtime" value="{{ $recipe->cookingtime }}">
+        @if ($errors->has('cookingtime'))
+          @foreach ($errors->get('cookingtime') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+      <div class="form-group">
+        <label for="description">説明</label>
+        <textarea class="form-control   "name="description" cols="30" rows="4" value="{{ $recipe->description }}"></textarea>
+        @if ($errors->has('cookingtime'))
+          @foreach ($errors->get('description') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+      <!-- TODO toolsテーブルを作成した後に追加する
+      道具(tools, checkbox)
+      <div class="form-group">
+        <label for="cookingtime">所要時間</label>
+        <input type="number" class="form-control" name="cookingtime" value="{{ $recipe->cookingtime }}">
+        @if ($errors->has('cookingtime'))
+          @foreach ($errors->get('cookingtime') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+       -->
+      <div class="form-group">
+        <label for="is_comment_allowed">コメント許可</label><br/>
+        <input type="radio" id="allowed" name="is_comment_allowed" value="0" checked="{{ $recipe->is_comment_allowed }}">
+        <label for="allowed">許可する</label>
+        <input type="radio" id="not_allowed" name="is_comment_allowed" value="0" checked="{{ $recipe->is_comment_allowed }}">
+        <label for="allowed">許可しない</label>
+        @if ($errors->has('is_comment_allowed'))
+          @foreach ($errors->get('is_comment_allowed') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+      <!-- TODO カテゴリーテーブルを作成して値を参照するセレクトボックスを作成する
+      カテゴリ(select_box)
+      <div class="form-group">
+        <label for="cookingtime">所要時間</label>
+        <input type="number" class="form-control" name="cookingtime" value="{{ $recipe->cookingtime }}">
+        @if ($errors->has('cookingtime'))
+          @foreach ($errors->get('cookingtime') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+      -->
+        <!-- TODO: 画像アップロード機能を追加する?
+        (file)
+      <div class="form-group">
+        <label for="cookingtime">所要時間</label>
+        <input type="number" class="form-control" name="cookingtime" value="{{ $recipe->cookingtime }}">
+        @if ($errors->has('cookingtime'))
+          @foreach ($errors->get('cookingtime') as $message)
+            <span class="text-danger">{{ $message }}</span><br>
+          @endforeach
+        @endif
+      </div>
+        -->
+      <button type="submit" class="btn btn-default">登録</button>
+      <input type="reset"  class="btn btn-default" value="リセット">
+      <a href="/recipe">戻る</a>
+      </form>
     </div>
+  </div>
 </div>

--- a/resources/views/recipe/form.blade.php
+++ b/resources/views/recipe/form.blade.php
@@ -55,7 +55,7 @@
        -->
       <div class="form-group">
         <label for="is_comment_allowed">コメント許可</label><br/>
-        <input type="radio" id="allowed" name="is_comment_allowed" value="0" checked="{{ $recipe->is_comment_allowed }}">
+        <input type="radio" id="allowed" name="is_comment_allowed" value="1" checked="{{ $recipe->is_comment_allowed }}">
         <label for="allowed">許可する</label>
         <input type="radio" id="not_allowed" name="is_comment_allowed" value="0" checked="{{ $recipe->is_comment_allowed }}">
         <label for="allowed">許可しない</label>

--- a/resources/views/recipe/index.blade.php
+++ b/resources/views/recipe/index.blade.php
@@ -13,6 +13,7 @@
           <th class="text-center">ID</th>
           <th class="text-center">レシピ名</th>
           <th class="text-center">所要時間</th>
+          <th class="text-center">コメント許可</th>
           <th></th>
         </tr>
         @foreach ($recipes as $recipe)
@@ -22,6 +23,11 @@
           </td>
           <td>{{ $recipe->name }}</td>
           <td>{{ $recipe->cookingtime }}</td>
+          <td>
+          @if($recipe->is_comment_allowed)
+              ○
+          @endif
+          </td>
           <td>
             <form action="/recipe/{{ $recipe->id }}" method="post">
               <input type="hidden" name="_method" value="DELETE">
@@ -47,6 +53,7 @@
           <th class="text-center">ID</th>
           <th class="text-center">レシピ名</th>
           <th class="text-center">所要時間</th>
+          <th class="text-center">コメント許可</th>
           <th></th>
         </tr>
         @foreach ($deleted_recipes as $deleted_recipe)
@@ -56,6 +63,11 @@
           </td>
           <td>{{ $deleted_recipe->name }}</td>
           <td>{{ $deleted_recipe->cookingtime }}</td>
+          <td>
+          @if($deleted_recipe->is_comment_allowed)
+              ○
+          @endif
+          </td>
           <td>
             <form action="/recipe/restore/{{ $deleted_recipe->id }}" method="get">
               <input type="hidden" name="_method" value="PATCH">


### PR DESCRIPTION
#25 の一部を実装する。
フォーム要素が「text」タイプだけしかない（全ての要素タイプを表示させてみる）
という課題に対して
input要素の number,radio,resetを追加、textarea要素を追加することを実装する。
input要素のcheckbox,select要素に関しては
recipeテーブルに結合させる別テーブル(category, tool)を作成
した後に実装する。
